### PR TITLE
RtYamlLines implemented + unit tests

### DIFF
--- a/src/main/java/com/amihaiemil/camel/EvenlyIndentedLine.java
+++ b/src/main/java/com/amihaiemil/camel/EvenlyIndentedLine.java
@@ -74,6 +74,6 @@ final class EvenlyIndentedLine implements YamlLine {
 
     @Override
     public String toString() {
-    	return this.line.toString();
+        return this.line.toString();
     }
 }

--- a/src/main/java/com/amihaiemil/camel/EvenlyIndentedLine.java
+++ b/src/main/java/com/amihaiemil/camel/EvenlyIndentedLine.java
@@ -72,4 +72,8 @@ final class EvenlyIndentedLine implements YamlLine {
         return indentation;
     }
 
+    @Override
+    public String toString() {
+    	return this.line.toString();
+    }
 }

--- a/src/main/java/com/amihaiemil/camel/RtYamlLine.java
+++ b/src/main/java/com/amihaiemil/camel/RtYamlLine.java
@@ -80,6 +80,6 @@ final class RtYamlLine implements YamlLine {
 
     @Override
     public String toString() {
-    	return this.value;
+        return this.value;
     }
 }

--- a/src/main/java/com/amihaiemil/camel/RtYamlLine.java
+++ b/src/main/java/com/amihaiemil/camel/RtYamlLine.java
@@ -78,4 +78,8 @@ final class RtYamlLine implements YamlLine {
         return index;
     }
 
+    @Override
+    public String toString() {
+    	return this.value;
+    }
 }

--- a/src/main/java/com/amihaiemil/camel/RtYamlLines.java
+++ b/src/main/java/com/amihaiemil/camel/RtYamlLines.java
@@ -1,0 +1,55 @@
+package com.amihaiemil.camel;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+/**
+ * YamlLines default implementation.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 1.0.0
+ */
+final class RtYamlLines implements YamlLines {
+
+	/**
+	 * Yaml lines.
+	 */
+	private Collection<YamlLine> lines;
+
+	/**
+	 * Ctor.
+	 * @param lines
+	 */
+	RtYamlLines (Collection<YamlLine> lines) {
+		this.lines = lines;
+	}
+
+	@Override
+	public Iterator<YamlLine> iterator() {
+		return this.lines.iterator();
+	}
+
+	@Override
+	public YamlLines contained() {
+		return null;
+	}
+
+	@Override
+	public YamlMapping toYamlMapping() {
+		return null;
+	}
+
+	@Override
+	public YamlSequence toYamlSequence() {
+		return null;
+	}
+
+	@Override
+	public String toString() {
+		final StringBuilder sb = new StringBuilder();
+		for (YamlLine line : lines) {
+			sb.append(line.toString()).append("\n");
+		}
+		return sb.toString();
+	}
+}

--- a/src/main/java/com/amihaiemil/camel/RtYamlLines.java
+++ b/src/main/java/com/amihaiemil/camel/RtYamlLines.java
@@ -1,55 +1,69 @@
 package com.amihaiemil.camel;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * YamlLines default implementation.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 1.0.0
+ * @todo #59:30min/DEV Implement and unit test method nested(...), as specified
+ *  in its javadoc.
  */
 final class RtYamlLines implements YamlLines {
 
-	/**
-	 * Yaml lines.
-	 */
-	private Collection<YamlLine> lines;
+    /**
+     * Yaml lines.
+     */
+    private Collection<YamlLine> lines;
 
-	/**
-	 * Ctor.
-	 * @param lines
-	 */
-	RtYamlLines (Collection<YamlLine> lines) {
-		this.lines = lines;
-	}
+    /**
+     * Ctor.
+     * @param lines Yaml lines collection.
+     */
+    RtYamlLines(final Collection<YamlLine> lines) {
+        this.lines = lines;
+    }
 
-	@Override
-	public Iterator<YamlLine> iterator() {
-		return this.lines.iterator();
-	}
+    /**
+     * Returns an iterator over these Yaml lines.
+     * It <b>only</b> iterates over the lines which are at the same
+     * level of indentation with the first!
+     * @return Iterator over these yaml lines.
+     */
+    @Override
+    public Iterator<YamlLine> iterator() {
+        Iterator<YamlLine> iterator = this.lines.iterator();
+        if (iterator.hasNext()) {
+            final List<YamlLine> sameIndentation = new ArrayList<>();
+            final YamlLine first = iterator.next();
+            sameIndentation.add(first);
+            while (iterator.hasNext()) {
+                YamlLine current = iterator.next();
+                if(current.indentation() == first.indentation()) {
+                    sameIndentation.add(current);
+                }
+            }
+            iterator = sameIndentation.iterator();
+        }
+        return iterator;
+    }
 
-	@Override
-	public YamlLines contained() {
-		return null;
-	}
+    @Override
+    public YamlLines nested(final int after) {
+        return null;
+    }
 
-	@Override
-	public YamlMapping toYamlMapping() {
-		return null;
-	}
+    @Override
+    public String toString() {
+        final StringBuilder builder = new StringBuilder();
+        for (final YamlLine line : this.lines) {
+            builder.append(line.toString()).append("\n");
+        }
+        return builder.toString();
+    }
 
-	@Override
-	public YamlSequence toYamlSequence() {
-		return null;
-	}
-
-	@Override
-	public String toString() {
-		final StringBuilder sb = new StringBuilder();
-		for (YamlLine line : lines) {
-			sb.append(line.toString()).append("\n");
-		}
-		return sb.toString();
-	}
 }

--- a/src/main/java/com/amihaiemil/camel/WellIndentedLine.java
+++ b/src/main/java/com/amihaiemil/camel/WellIndentedLine.java
@@ -92,5 +92,9 @@ final class WellIndentedLine implements YamlLine {
         }
         return lineIndent;
     }
-    
+
+    @Override
+    public String toString() {
+    	return this.line.toString();
+    }
 }

--- a/src/main/java/com/amihaiemil/camel/WellIndentedLine.java
+++ b/src/main/java/com/amihaiemil/camel/WellIndentedLine.java
@@ -95,6 +95,6 @@ final class WellIndentedLine implements YamlLine {
 
     @Override
     public String toString() {
-    	return this.line.toString();
+        return this.line.toString();
     }
 }

--- a/src/main/java/com/amihaiemil/camel/YamlInput.java
+++ b/src/main/java/com/amihaiemil/camel/YamlInput.java
@@ -27,6 +27,8 @@
  */
 package com.amihaiemil.camel;
 
+import java.io.IOException;
+
 /**
  * Yaml input.
  * @author Mihai Andronache (amihaiemil@gmail.com)
@@ -38,13 +40,15 @@ public interface YamlInput {
     /**
      * Read the given input as a Yaml mapping.
      * @return Read YamlMapping.
+     * @throws IOException if the input cannot be read for some reason
      */
-    YamlMapping readYamlMapping();
+    YamlMapping readYamlMapping() throws IOException;
 
     /**
      * Read the given input as a Yaml sequence.
      * @return Read YamlSequence.
+     * @throws IOException if the input cannot be read for some reason
      */
-    YamlSequence readYamlSequence();
+    YamlSequence readYamlSequence() throws IOException;
 
 }

--- a/src/main/java/com/amihaiemil/camel/YamlLine.java
+++ b/src/main/java/com/amihaiemil/camel/YamlLine.java
@@ -55,4 +55,26 @@ interface YamlLine {
      * @throws IllegalStateException if the indentation is not multiple of 2.
      */
     int indentation();
+    
+    /**
+     * YamlLine null object.
+     */
+    static class NullYamlLine implements YamlLine {
+
+        @Override
+        public String trimmed() {
+            return "";
+        }
+
+        @Override
+        public int number() {
+            return -1;
+        }
+
+        @Override
+        public int indentation() {
+            return 0;    
+        }
+        
+    }
 }

--- a/src/main/java/com/amihaiemil/camel/YamlLine.java
+++ b/src/main/java/com/amihaiemil/camel/YamlLine.java
@@ -59,7 +59,7 @@ interface YamlLine {
     /**
      * YamlLine null object.
      */
-    static class NullYamlLine implements YamlLine {
+    class NullYamlLine implements YamlLine {
 
         @Override
         public String trimmed() {

--- a/src/main/java/com/amihaiemil/camel/YamlLines.java
+++ b/src/main/java/com/amihaiemil/camel/YamlLines.java
@@ -32,29 +32,15 @@ package com.amihaiemil.camel;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 1.0.0
- * @todo #52:1h Implement and unit test this interface. It should
- *  be named RtYamlLines and be a default-accessible class.
  */
 interface YamlLines extends Iterable<YamlLine> {
 
     /**
-     * Lines which are contained within the current YamlLine (lines which are 
+     * Lines which are nested after the given YamlLine (lines which are 
      * <br> indented by 2 or more spaces beneath it).
+     * @param after Number of a YamlLine
      * @return YamlLines
      */
-    YamlLines contained();
-
-    /**
-     * Turn these lines into a Yaml mapping.
-     * @return YamlMapping.
-     */
-    YamlMapping toYamlMapping();
-
-    /**
-     * Turn these lines into a Yaml sequence.
-     * @return YamlSequence.
-     */
-    YamlSequence toYamlSequence();
-    
+    YamlLines nested(final int after);
     
 }

--- a/src/main/java/com/amihaiemil/camel/YamlMapping.java
+++ b/src/main/java/com/amihaiemil/camel/YamlMapping.java
@@ -32,6 +32,9 @@ package com.amihaiemil.camel;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 1.0.0
+ * @todo 59:30min/DEV We should implement class ReadYamlMapping, which
+ *  should implement this interface. The class will encapsulate and
+ *  work with YamlLines.
  */
 public interface YamlMapping extends YamlNode{
 

--- a/src/main/java/com/amihaiemil/camel/YamlSequence.java
+++ b/src/main/java/com/amihaiemil/camel/YamlSequence.java
@@ -5,6 +5,9 @@ package com.amihaiemil.camel;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 1.0.0
+ * @todo 59:30min/DEV We should implement class ReadYamlSequence, which
+ *  should implement this interface. The class will encapsulate and
+ *  work with YamlLines.
  */
 public interface YamlSequence extends YamlNode {
 

--- a/src/test/java/com/amihaiemil/camel/RtYamlLineTest.java
+++ b/src/test/java/com/amihaiemil/camel/RtYamlLineTest.java
@@ -32,7 +32,7 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
- * Unit tests for {@link RtYamlLine}
+ * Unit tests for {@link RtYamlLine}.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 1.0.0

--- a/src/test/java/com/amihaiemil/camel/RtYamlLineTest.java
+++ b/src/test/java/com/amihaiemil/camel/RtYamlLineTest.java
@@ -27,68 +27,44 @@
  */
 package com.amihaiemil.camel;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
 
 /**
- * Implementation for {@link YamlInput}.
+ * Unit tests for {@link RtYamlLine}
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 1.0.0
  */
-final class RtYamlInput implements YamlInput {
-
+public final class RtYamlLineTest {
+    
     /**
-     * Source of the input.
+     * RtYamlLine knows its number.
      */
-    private InputStream source;
-
-    /**
-     * Ctor.
-     * @param source Given source.
-     */
-    RtYamlInput(final InputStream source) {
-        this.source = source;
-    }
-
-    @Override
-    public YamlMapping readYamlMapping() throws IOException {
-    	return this.readInput().toYamlMapping();
-    }
-
-    @Override
-    public YamlSequence readYamlSequence() throws IOException {
-        return this.readInput().toYamlSequence();
+    @Test
+    public void knowsNumber() {
+        YamlLine line = new RtYamlLine("this line", 12);
+        MatcherAssert.assertThat(line.number(), Matchers.is(12));
     }
 
     /**
-     * Read the input's lines.
-     * @return YamlLines
-     * @throws IOException If something goes wrong while reading the input.
+     * RtYamlLine can trim itself.
      */
-    private YamlLines readInput() throws IOException {
-        List<YamlLine> lines = new ArrayList<>();
-        try (
-            BufferedReader reader = new BufferedReader(
-                new InputStreamReader(this.source)
-            )
-        ) {
-        	String line;
-            int number = 0;
-            YamlLine previous = new YamlLine.NullYamlLine();
-            while ((line = reader.readLine()) != null) {
-            	final YamlLine current = new RtYamlLine(line, number);
-                lines.add(
-                    new WellIndentedLine(previous, current)
-                );
-                number++;
-                previous = current;
-            }
-        }
-        return new RtYamlLines(lines);
+    @Test
+    public void trimmsItself() {
+        YamlLine line = new RtYamlLine("   this: line   ", 10);
+        MatcherAssert.assertThat(
+            line.trimmed(), Matchers.equalTo("this: line")
+        );
+    }
+
+    /**
+     * RtYamlLine returns indentation.
+     */
+    @Test
+    public void knowsIndentation() {
+        YamlLine line = new RtYamlLine("this: line", 5);
+        MatcherAssert.assertThat(line.indentation(), Matchers.is(0));
     }
 }

--- a/src/test/java/com/amihaiemil/camel/RtYamlLinesTest.java
+++ b/src/test/java/com/amihaiemil/camel/RtYamlLinesTest.java
@@ -27,68 +27,39 @@
  */
 package com.amihaiemil.camel;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
 /**
- * Implementation for {@link YamlInput}.
+ * Unit tests for {@link RtYamlLines}.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
- * @since 1.0.0
+ * @sinve 1.0.0
  */
-final class RtYamlInput implements YamlInput {
+public final class RtYamlLinesTest {
 
     /**
-     * Source of the input.
+     * RtYamlLines can iterate over the lines properly.
+     * It should iterate only over the lines which are at the
+     * same indentation level.
      */
-    private InputStream source;
-
-    /**
-     * Ctor.
-     * @param source Given source.
-     */
-    RtYamlInput(final InputStream source) {
-        this.source = source;
-    }
-
-    @Override
-    public YamlMapping readYamlMapping() throws IOException {
-        return null;
-    }
-
-    @Override
-    public YamlSequence readYamlSequence() throws IOException {
-        return null;
-    }
-
-    /**
-     * Read the input's lines.
-     * @return YamlLines
-     * @throws IOException If something goes wrong while reading the input.
-     */
-    private YamlLines readInput() throws IOException {
-        List<YamlLine> lines = new ArrayList<>();
-        try (
-            BufferedReader reader = new BufferedReader(
-                new InputStreamReader(this.source)
-            )
-        ) {
-            String line;
-            int number = 0;
-            YamlLine previous = new YamlLine.NullYamlLine();
-            while ((line = reader.readLine()) != null) {
-                final YamlLine current = new RtYamlLine(line, number);
-                lines.add(
-                    new WellIndentedLine(previous, current)
-                );
-                number++;
-                previous = current;
-            }
-        }
-        return new RtYamlLines(lines);
+    @Test
+    public void iteratesRight() {
+        final List<YamlLine> lines = new ArrayList<>();
+        lines.add(new RtYamlLine("first: ", 0));
+        lines.add(new RtYamlLine("  - fourth", 1));
+        lines.add(new RtYamlLine("  - fifth", 2));
+        lines.add(new RtYamlLine("second: something", 3));
+        lines.add(new RtYamlLine("third: somethingElse", 4));
+        final Iterator<YamlLine> iterator = new RtYamlLines(lines).iterator();
+        MatcherAssert.assertThat(iterator.next().number(), Matchers.is(0));
+        MatcherAssert.assertThat(iterator.next().number(), Matchers.is(3));
+        MatcherAssert.assertThat(iterator.next().number(), Matchers.is(4));
+        MatcherAssert.assertThat(iterator.hasNext(), Matchers.is(false));
     }
 }

--- a/src/test/java/com/amihaiemil/camel/RtYamlMappingTest.java
+++ b/src/test/java/com/amihaiemil/camel/RtYamlMappingTest.java
@@ -27,7 +27,6 @@
  */
 package com.amihaiemil.camel;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -293,8 +292,6 @@ public final class RtYamlMappingTest {
             .build();
         String expected = this.readTestResource("complexMapping.yml");
         MatcherAssert.assertThat(yaml.toString(), Matchers.equalTo(expected));
-        YamlInput input = new RtYamlInput(new ByteArrayInputStream(expected.getBytes()));
-        input.readYamlMapping();
     }
 
     /**

--- a/src/test/java/com/amihaiemil/camel/RtYamlMappingTest.java
+++ b/src/test/java/com/amihaiemil/camel/RtYamlMappingTest.java
@@ -27,6 +27,7 @@
  */
 package com.amihaiemil.camel;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -292,6 +293,8 @@ public final class RtYamlMappingTest {
             .build();
         String expected = this.readTestResource("complexMapping.yml");
         MatcherAssert.assertThat(yaml.toString(), Matchers.equalTo(expected));
+        YamlInput input = new RtYamlInput(new ByteArrayInputStream(expected.getBytes()));
+        input.readYamlMapping();
     }
 
     /**

--- a/src/test/java/com/amihaiemil/camel/WellIndentedLineTest.java
+++ b/src/test/java/com/amihaiemil/camel/WellIndentedLineTest.java
@@ -71,7 +71,7 @@ public final class WellIndentedLineTest {
      */
     @Test
     public void isWellIndented() {
-    	YamlLine line = new WellIndentedLine(
+        YamlLine line = new WellIndentedLine(
             new RtYamlLine("previusline: ", 9),
             new RtYamlLine("  this: line", 10)
         );

--- a/src/test/java/com/amihaiemil/camel/WellIndentedLineTest.java
+++ b/src/test/java/com/amihaiemil/camel/WellIndentedLineTest.java
@@ -71,7 +71,7 @@ public final class WellIndentedLineTest {
      */
     @Test
     public void isWellIndented() {
-        YamlLine line = new WellIndentedLine(
+    	YamlLine line = new WellIndentedLine(
             new RtYamlLine("previusline: ", 9),
             new RtYamlLine("  this: line", 10)
         );


### PR DESCRIPTION
PR for #59 
Also did some refactoring.
``YamlLines`` loses the methods ``toYaml*()``.

Instead, new ``YamlMapping`` and ``YamlSequence`` implementations (left puzzle for them) will work directly with ``YamlLines``. There will also be some caching decorators implemented for them, so the look-up algorithm is not performed every time a method is called.