### PR TITLE
Methods in ReadYamlMapping and unit tests

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -178,7 +178,9 @@
         <module name="SimplifyBooleanReturn"/>
         <module name="StringLiteralEquality"/>
         <module name="NestedForDepth"/>
-        <module name="NestedIfDepth"/>
+        <module name="NestedIfDepth">
+            <property name="max" value="3"/>
+        </module>
         <module name="NestedTryDepth"/>
         <module name="NoClone"/>
         <module name="NoFinalizer"/>

--- a/src/main/java/com/amihaiemil/camel/AbstractYamlLines.java
+++ b/src/main/java/com/amihaiemil/camel/AbstractYamlLines.java
@@ -44,6 +44,12 @@ abstract class AbstractYamlLines implements Iterable<YamlLine> {
     abstract AbstractYamlLines nested(final int after);
 
     /**
+     * Number of lines.
+     * @return Integer.
+     */
+    abstract int count();
+
+    /**
      * Turn these lines into a YamlNode.
      * @return YamlNode
      */

--- a/src/main/java/com/amihaiemil/camel/OrderedYamlLines.java
+++ b/src/main/java/com/amihaiemil/camel/OrderedYamlLines.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2016-2017, Mihai Emil Andronache
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ * Neither the name of the copyright holder nor the names of its
+ *  contributors may be used to endorse or promote products derived from
+ *  this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+package com.amihaiemil.camel;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Ordered YamlLines.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 1.0.0
+ */
+final class OrderedYamlLines extends AbstractYamlLines {
+
+    /**
+     * Lines to order.
+     */
+    private AbstractYamlLines unordered;
+
+    /**
+     * Ctor.
+     * @param unordered Decorated lines.
+     */
+    OrderedYamlLines(final AbstractYamlLines unordered) {
+        this.unordered = unordered;
+    }
+
+    /**
+     * Iterates over the lines with the same indentation. The lines
+     * are ordered.
+     * @return Iterator over the ordered lines.
+     */
+    @Override
+    public Iterator<YamlLine> iterator() {
+        final Iterator<YamlLine> lines = this.unordered.iterator();
+        final List<YamlLine> ordered = new LinkedList<>();
+        while (lines.hasNext()) {
+            ordered.add(lines.next());
+        }
+        Collections.sort(ordered);
+        return ordered.iterator();
+    }
+
+    /**
+     * Returns the lines which are nested after the given line. 
+     * The lines are not necessarily ordered. If the resulting lines
+     * should be ordered (be iterated in order), then they have
+     * to be wrapped inside a new OrderedYamlLines.
+     * @return AbstractYamlLines
+     * @param after The number of the parent line
+     */
+    @Override
+    AbstractYamlLines nested(final int after) {
+        return this.unordered.nested(after);
+    }
+
+    @Override
+    int count() {
+        return this.unordered.count();
+    }
+
+}

--- a/src/main/java/com/amihaiemil/camel/ReadYamlMapping.java
+++ b/src/main/java/com/amihaiemil/camel/ReadYamlMapping.java
@@ -59,13 +59,14 @@ final class ReadYamlMapping extends AbstractYamlMapping {
     @Override
     public Collection<YamlNode> children() {
         final List<YamlNode> kids = new LinkedList<>();
-        for (final YamlLine line : this.lines) {
+        final OrderedYamlLines ordered = new OrderedYamlLines(this.lines);
+        for (final YamlLine line : ordered) {
             final String trimmed = line.trimmed();
             if("?".equals(trimmed) || ":".equals(trimmed)) {
                 continue;
             } else {
                 if(trimmed.endsWith(":")) {
-                    kids.add(this.lines.nested(line.number()).toYamlNode());
+                    kids.add(ordered.nested(line.number()).toYamlNode());
                 } else {
                     final String[] parts = trimmed.split(":");
                     if(parts.length < 2) {

--- a/src/main/java/com/amihaiemil/camel/RtYamlLines.java
+++ b/src/main/java/com/amihaiemil/camel/RtYamlLines.java
@@ -2,7 +2,6 @@ package com.amihaiemil.camel;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -46,7 +45,6 @@ final class RtYamlLines extends AbstractYamlLines {
                     sameIndentation.add(current);
                 }
             }
-            Collections.sort(sameIndentation);
             iterator = sameIndentation.iterator();
         }
         return iterator;
@@ -56,7 +54,7 @@ final class RtYamlLines extends AbstractYamlLines {
     AbstractYamlLines nested(final int after) {
         final List<YamlLine> nestedLines = new ArrayList<YamlLine>();
         YamlLine start = null;
-        for(final YamlLine line: this.lines) {
+        for(final YamlLine line : this.lines) {
             if(line.number() == after) {
                 start = line;
             }

--- a/src/main/java/com/amihaiemil/camel/RtYamlLines.java
+++ b/src/main/java/com/amihaiemil/camel/RtYamlLines.java
@@ -2,6 +2,7 @@ package com.amihaiemil.camel;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -45,13 +46,14 @@ final class RtYamlLines extends AbstractYamlLines {
                     sameIndentation.add(current);
                 }
             }
+            Collections.sort(sameIndentation);
             iterator = sameIndentation.iterator();
         }
         return iterator;
     }
 
     @Override
-    public AbstractYamlLines nested(final int after) {
+    AbstractYamlLines nested(final int after) {
         final List<YamlLine> nestedLines = new ArrayList<YamlLine>();
         YamlLine start = null;
         for(final YamlLine line: this.lines) {
@@ -76,6 +78,11 @@ final class RtYamlLines extends AbstractYamlLines {
             builder.append(line.toString()).append("\n");
         }
         return builder.toString();
+    }
+
+    @Override
+    int count() {
+        return this.lines.size();
     }
 
 

--- a/src/test/java/com/amihaiemil/camel/OrderedYamlLinesTest.java
+++ b/src/test/java/com/amihaiemil/camel/OrderedYamlLinesTest.java
@@ -28,6 +28,7 @@
 package com.amihaiemil.camel;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -36,15 +37,15 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
- * Unit tests for {@link RtYamlLines}.
+ * Unit tests for {@link OrderedYamlLines}.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
- * @sinve 1.0.0
+ * @since 1.0.0
  */
-public final class RtYamlLinesTest {
+public final class OrderedYamlLinesTest {
 
     /**
-     * RtYamlLines can iterate over the lines properly.
+     * OrderedYamlLines can iterate over the ordered lines properly.
      * It should iterate only over the lines which are at the
      * same indentation level.
      */
@@ -54,24 +55,27 @@ public final class RtYamlLinesTest {
         lines.add(new RtYamlLine("first: ", 0));
         lines.add(new RtYamlLine("  - fourth", 1));
         lines.add(new RtYamlLine("  - fifth", 2));
-        lines.add(new RtYamlLine("second: something", 3));
-        lines.add(new RtYamlLine("third: somethingElse", 4));
-        final Iterator<YamlLine> iterator = new RtYamlLines(lines).iterator();
-        MatcherAssert.assertThat(iterator.next().number(), Matchers.is(0));
-        MatcherAssert.assertThat(iterator.next().number(), Matchers.is(3));
+        lines.add(new RtYamlLine("bay: something", 3));
+        lines.add(new RtYamlLine("alba: somethingElse", 4));
+        final Iterator<YamlLine> iterator = new OrderedYamlLines(
+            new RtYamlLines(lines)
+        ).iterator();
         MatcherAssert.assertThat(iterator.next().number(), Matchers.is(4));
+        MatcherAssert.assertThat(iterator.next().number(), Matchers.is(3));
+        MatcherAssert.assertThat(iterator.next().number(), Matchers.is(0));
         MatcherAssert.assertThat(iterator.hasNext(), Matchers.is(false));
     }
     
     /**
-     * RtYamlLines can return nested lines for a given line.
+     * OrderedYamlLines can return nested lines (in initial order) for a given
+     * line.
      */
     @Test
     public void returnsNestedLinesRight() {
         final List<YamlLine> lines = new ArrayList<>();
         lines.add(new RtYamlLine("first: ", 0));
-        lines.add(new RtYamlLine("  - fourth", 1));
-        lines.add(new RtYamlLine("  - fifth", 2));
+        lines.add(new RtYamlLine("  - bay", 1));
+        lines.add(new RtYamlLine("  - alba", 2));
         lines.add(new RtYamlLine("second: something", 3));
         lines.add(new RtYamlLine("third: somethingElse", 4));
         lines.add(new RtYamlLine("  - sixth", 5));
@@ -93,4 +97,27 @@ public final class RtYamlLinesTest {
         MatcherAssert.assertThat(iterator.hasNext(), Matchers.is(false));
     }
 
+    /**
+     * Test to check that YamlLine.compareTo(...) works fine.
+     */
+    @Test
+    public void yamlLinesAreOrdered() {
+        final List<YamlLine> lines = new ArrayList<>();
+        lines.add(new RtYamlLine("Einestien", 0));
+        lines.add(new RtYamlLine("  Ben", 1));
+        lines.add(new RtYamlLine("Charles", 2));
+        lines.add(new RtYamlLine("    Denise", 3));
+        lines.add(new RtYamlLine("      Albert", 4));
+        lines.add(new RtYamlLine("Sherif", 5));
+        Collections.sort(lines);
+        
+        Iterator<YamlLine> iterator = lines.iterator();
+        MatcherAssert.assertThat(iterator.next().number(), Matchers.is(4));
+        MatcherAssert.assertThat(iterator.next().number(), Matchers.is(1));
+        MatcherAssert.assertThat(iterator.next().number(), Matchers.is(2));
+        MatcherAssert.assertThat(iterator.next().number(), Matchers.is(3));
+        MatcherAssert.assertThat(iterator.next().number(), Matchers.is(0));
+        MatcherAssert.assertThat(iterator.next().number(), Matchers.is(5));
+        MatcherAssert.assertThat(iterator.hasNext(), Matchers.is(false));
+    }
 }

--- a/src/test/java/com/amihaiemil/camel/ReadYamlMappingTest.java
+++ b/src/test/java/com/amihaiemil/camel/ReadYamlMappingTest.java
@@ -61,6 +61,36 @@ public final class ReadYamlMappingTest {
         MatcherAssert.assertThat(
             second, Matchers.instanceOf(YamlMapping.class)
         );
+        MatcherAssert.assertThat(
+            second.string("fifth"), Matchers.equalTo("values")
+        );
+    }
+    
+    /**
+     * ReadYamlMapping can return the YamlMapping mapped to a
+     * YamlMapping key.
+     */
+    @Test
+    public void returnsYamlMappingWithYamlMappingKey(){
+        final YamlMapping key = new RtYamlMappingBuilder()
+            .add("complex1", "mapping1").add("complex2", "mapping2").build();
+        final List<YamlLine> lines = new ArrayList<>();
+        lines.add(new RtYamlLine("first: something", 0));
+        lines.add(new RtYamlLine("? ", 1));
+        lines.add(new RtYamlLine("  complex1: mapping1", 2));
+        lines.add(new RtYamlLine("  complex2: mapping2", 3));
+        lines.add(new RtYamlLine(": ", 4));
+        lines.add(new RtYamlLine("  map: value", 5));
+        lines.add(new RtYamlLine("second: something", 6));
+        final YamlMapping map = new ReadYamlMapping(new RtYamlLines(lines));
+        final YamlMapping value = map.yamlMapping(key);
+        MatcherAssert.assertThat(value, Matchers.notNullValue());
+        MatcherAssert.assertThat(
+            value, Matchers.instanceOf(YamlMapping.class)
+        );
+        MatcherAssert.assertThat(
+            value.string("map"), Matchers.equalTo("value")
+        );
     }
 
     /**
@@ -82,7 +112,28 @@ public final class ReadYamlMappingTest {
             second, Matchers.instanceOf(YamlSequence.class)
         );
     }
-
+    
+    /**
+     * ReadYamlMapping can return the YamlMapping mapped to a
+     * YamlMapping key.
+     */
+    @Test
+    public void returnsStringWithYamlMappingKey(){
+        final YamlMapping key = new RtYamlMappingBuilder()
+            .add("complex1", "mapping1").add("complex2", "mapping2").build();
+        final List<YamlLine> lines = new ArrayList<>();
+        lines.add(new RtYamlLine("first: something", 0));
+        lines.add(new RtYamlLine("? ", 1));
+        lines.add(new RtYamlLine("  complex1: mapping1", 2));
+        lines.add(new RtYamlLine("  complex2: mapping2", 3));
+        lines.add(new RtYamlLine(": value", 4));
+        lines.add(new RtYamlLine("second: something", 6));
+        final YamlMapping map = new ReadYamlMapping(new RtYamlLines(lines));
+        final String value = map.string(key);
+        MatcherAssert.assertThat(value, Matchers.notNullValue());
+        MatcherAssert.assertThat(value, Matchers.equalTo("value"));
+    }
+    
     /**
      * ReadYamlMapping can return the String mapped to a
      * String key.

--- a/src/test/java/com/amihaiemil/camel/RtYamlLinesTest.java
+++ b/src/test/java/com/amihaiemil/camel/RtYamlLinesTest.java
@@ -79,8 +79,8 @@ public final class RtYamlLinesTest {
         AbstractYamlLines yamlLines = new RtYamlLines(lines);
         
         Iterator<YamlLine> iterator = yamlLines.nested(0).iterator();
-        MatcherAssert.assertThat(iterator.next().number(), Matchers.is(1));
         MatcherAssert.assertThat(iterator.next().number(), Matchers.is(2));
+        MatcherAssert.assertThat(iterator.next().number(), Matchers.is(1));
         MatcherAssert.assertThat(iterator.hasNext(), Matchers.is(false));
         
         iterator = yamlLines.nested(1).iterator();


### PR DESCRIPTION
PR for #73 

Added ``OrderedYamlLines`` decorator, to separate concerns, because having RtYamlLines always ordering the lines is not correct; we don't always want the lines to be ordered - for instance, method ``ReadYamlMapping.string(YamlNode)`` doesn't work right if the lines are ordered