### PR TITLE
Finished implementing ReadYamlMapping

### DIFF
--- a/src/main/java/com/amihaiemil/camel/AbstractYamlLines.java
+++ b/src/main/java/com/amihaiemil/camel/AbstractYamlLines.java
@@ -50,6 +50,13 @@ abstract class AbstractYamlLines implements Iterable<YamlLine> {
     abstract int count();
 
     /**
+     * Indent these lines.
+     * @param indentation Spaces to precede each line.
+     * @return String with the pretty-printed, indented lines.
+     */
+    abstract String indent (int indentation);
+    
+    /**
      * Turn these lines into a YamlNode.
      * @return YamlNode
      */
@@ -64,5 +71,5 @@ abstract class AbstractYamlLines implements Iterable<YamlLine> {
         }
         return node;
     }
-    
+
 }

--- a/src/main/java/com/amihaiemil/camel/AbstractYamlLines.java
+++ b/src/main/java/com/amihaiemil/camel/AbstractYamlLines.java
@@ -54,7 +54,7 @@ abstract class AbstractYamlLines implements Iterable<YamlLine> {
      * @param indentation Spaces to precede each line.
      * @return String with the pretty-printed, indented lines.
      */
-    abstract String indent (int indentation);
+    abstract String indent(int indentation);
     
     /**
      * Turn these lines into a YamlNode.

--- a/src/main/java/com/amihaiemil/camel/OrderedYamlLines.java
+++ b/src/main/java/com/amihaiemil/camel/OrderedYamlLines.java
@@ -87,4 +87,10 @@ final class OrderedYamlLines extends AbstractYamlLines {
         return this.unordered.count();
     }
 
+	@Override
+	String indent(int indentation) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
 }

--- a/src/main/java/com/amihaiemil/camel/OrderedYamlLines.java
+++ b/src/main/java/com/amihaiemil/camel/OrderedYamlLines.java
@@ -33,7 +33,8 @@ import java.util.LinkedList;
 import java.util.List;
 
 /**
- * Ordered YamlLines.
+ * Ordered YamlLines. Use this decorator only punctually, when it the
+ * AbstractYamlLines you're working with need to be ordered.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 1.0.0
@@ -87,10 +88,42 @@ final class OrderedYamlLines extends AbstractYamlLines {
         return this.unordered.count();
     }
 
-	@Override
-	String indent(int indentation) {
-		// TODO Auto-generated method stub
-		return null;
-	}
+    @Override
+    String indent(final int indentation) {
+        final StringBuilder indented = new StringBuilder();
+        final Iterator<YamlLine> linesIt = this.iterator();
+        final YamlLine first = linesIt.next();
+        final int offset = indentation - first.indentation();
+        indented.append(this.indentLine(first, offset));
+        while(linesIt.hasNext()) {
+            indented.append(
+                this.indentLine(linesIt.next(), offset)
+            );
+        }
+        return indented.toString();
+    }
 
+    /**
+     * Indent the given line (and its possible nested nodes) with the given
+     * offset.
+     * @param line YamlLine to indent.
+     * @param offset Offset added to its already existing indentation.
+     * @return String indented result.
+     */
+    private String indentLine(final YamlLine line, final int offset){
+        final StringBuilder indented = new StringBuilder();
+        int indentation = line.indentation() + offset;
+        while (indentation > 0) {
+            indented.append(" ");
+            indentation--;
+        }
+        indented.append(line.toString()).append("\n");
+        if (line.hasNestedNode()) {
+            final OrderedYamlLines nested = new OrderedYamlLines(
+                this.unordered.nested(line.number())
+            );
+            indented.append(nested.indent(indentation + offset));
+        }
+        return indented.toString();
+    }
 }

--- a/src/main/java/com/amihaiemil/camel/ReadYamlMapping.java
+++ b/src/main/java/com/amihaiemil/camel/ReadYamlMapping.java
@@ -38,8 +38,6 @@ import java.util.Set;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 1.0.0
- * @todo #73:30min/DEV Continue implementing and unit-testing the methods
- *  from this class one by one.
  */
 final class ReadYamlMapping extends AbstractYamlMapping {
 
@@ -149,7 +147,7 @@ final class ReadYamlMapping extends AbstractYamlMapping {
 
     @Override
     public String indent(final int indentation) {
-        return null;
+        return this.lines.indent(indentation);
     }
 
     /**

--- a/src/main/java/com/amihaiemil/camel/ReadYamlSequence.java
+++ b/src/main/java/com/amihaiemil/camel/ReadYamlSequence.java
@@ -30,9 +30,13 @@ final class ReadYamlSequence extends AbstractYamlSequence {
         return null;
     }
 
+    @Override public String toString() {
+        return this.indent(0);
+    }
+
     @Override
     public String indent(final int indentation) {
-        return null;
+        return this.lines.indent(indentation);
     }
 
     @Override

--- a/src/main/java/com/amihaiemil/camel/RtYamlLines.java
+++ b/src/main/java/com/amihaiemil/camel/RtYamlLines.java
@@ -83,5 +83,29 @@ final class RtYamlLines extends AbstractYamlLines {
         return this.lines.size();
     }
 
+    @Override
+    String indent(final int indentation) {
+        final StringBuilder indented = new StringBuilder();
+        final Iterator<YamlLine> linesIt = this.lines.iterator();
+        final YamlLine first = linesIt.next();
+        if (first.indentation() == indentation) {
+            indented.append(first.toString()).append("\n");
+            while (linesIt.hasNext()) {
+                indented.append(linesIt.next().toString()).append("\n");
+            }
+        } else {
+        	final int offset = indentation - first.indentation();
+            for (YamlLine line : lines) {
+            	int correct = line.indentation() + offset;
+                while (correct > 0) {
+                	indented.append(" ");
+                	correct--;
+                }
+                indented.append(line.trimmed()).append("\n");
+            }
+        }
+        return indented.toString();
+    }
+
 
 }

--- a/src/main/java/com/amihaiemil/camel/RtYamlLines.java
+++ b/src/main/java/com/amihaiemil/camel/RtYamlLines.java
@@ -94,12 +94,12 @@ final class RtYamlLines extends AbstractYamlLines {
                 indented.append(linesIt.next().toString()).append("\n");
             }
         } else {
-        	final int offset = indentation - first.indentation();
-            for (YamlLine line : lines) {
-            	int correct = line.indentation() + offset;
+            final int offset = indentation - first.indentation();
+            for (final YamlLine line : this.lines) {
+                int correct = line.indentation() + offset;
                 while (correct > 0) {
-                	indented.append(" ");
-                	correct--;
+                    indented.append(" ");
+                    correct--;
                 }
                 indented.append(line.trimmed()).append("\n");
             }

--- a/src/test/java/com/amihaiemil/camel/OrderedYamlLinesTest.java
+++ b/src/test/java/com/amihaiemil/camel/OrderedYamlLinesTest.java
@@ -67,6 +67,28 @@ public final class OrderedYamlLinesTest {
     }
     
     /**
+     * OrderedYamlLines can indent the ordered lines properly.
+     */
+    @Test
+    public void indentsRight() {
+        final List<YamlLine> lines = new ArrayList<>();
+        lines.add(new RtYamlLine("fish: ", 0));
+        lines.add(new RtYamlLine("  - beta", 1));
+        lines.add(new RtYamlLine("  - alfa", 2));
+        lines.add(new RtYamlLine("bear: something", 3));
+        lines.add(new RtYamlLine("fox: somethingElse", 4));
+        final AbstractYamlLines yaml = new OrderedYamlLines(
+            new RtYamlLines(lines)
+        );
+        String expected = "bear: something\n"
+            + "fish: \n"
+            + "  - alfa\n"
+            + "  - beta\n"
+            + "fox: somethingElse\n";
+        MatcherAssert.assertThat(yaml.indent(0), Matchers.equalTo(expected));
+    }
+    
+    /**
      * OrderedYamlLines can return nested lines (in initial order) for a given
      * line.
      */

--- a/src/test/java/com/amihaiemil/camel/RtYamlLinesTest.java
+++ b/src/test/java/com/amihaiemil/camel/RtYamlLinesTest.java
@@ -75,7 +75,12 @@ public final class RtYamlLinesTest {
         lines.add(new RtYamlLine("  second: something", 3));
         lines.add(new RtYamlLine("  third: somethingElse", 4));
         final AbstractYamlLines yaml = new RtYamlLines(lines);
-        System.out.println(yaml.indent(0));
+        String expected = "first:\n"
+            + "  - fourth\n"
+            + "  - fifth\n"
+            + "second: something\n"
+            + "third: somethingElse\n";
+        MatcherAssert.assertThat(yaml.indent(0), Matchers.equalTo(expected));
     }
     
     /**

--- a/src/test/java/com/amihaiemil/camel/RtYamlLinesTest.java
+++ b/src/test/java/com/amihaiemil/camel/RtYamlLinesTest.java
@@ -64,6 +64,21 @@ public final class RtYamlLinesTest {
     }
     
     /**
+     * RtYamlLines can indent the lines properly.
+     */
+    @Test
+    public void indentsRight() {
+        final List<YamlLine> lines = new ArrayList<>();
+        lines.add(new RtYamlLine("  first: ", 0));
+        lines.add(new RtYamlLine("    - fourth", 1));
+        lines.add(new RtYamlLine("    - fifth", 2));
+        lines.add(new RtYamlLine("  second: something", 3));
+        lines.add(new RtYamlLine("  third: somethingElse", 4));
+        final AbstractYamlLines yaml = new RtYamlLines(lines);
+        System.out.println(yaml.indent(0));
+    }
+    
+    /**
      * RtYamlLines can return nested lines for a given line.
      */
     @Test

--- a/src/test/java/com/amihaiemil/camel/ScalarTest.java
+++ b/src/test/java/com/amihaiemil/camel/ScalarTest.java
@@ -65,6 +65,12 @@ public final class ScalarTest {
         MatcherAssert.assertThat(
             scl.children(), Matchers.emptyIterable()
         );
+        for (int i=0; i<10;i++) {
+        	for (int j=0; j<10;j++) {
+        		System.out.print(i + " x " + j + " = " + i*j + " | ");
+            }
+        	System.out.println();
+        }
     }
 
     /**

--- a/src/test/java/com/amihaiemil/camel/ScalarTest.java
+++ b/src/test/java/com/amihaiemil/camel/ScalarTest.java
@@ -65,12 +65,6 @@ public final class ScalarTest {
         MatcherAssert.assertThat(
             scl.children(), Matchers.emptyIterable()
         );
-        for (int i=0; i<10;i++) {
-        	for (int j=0; j<10;j++) {
-        		System.out.print(i + " x " + j + " = " + i*j + " | ");
-            }
-        	System.out.println();
-        }
     }
 
     /**


### PR DESCRIPTION
PR for #79 
Indentation is implemented within YamlLines, because they also have to be ordered. Also, the lines' indentation logic is common for ReadYamlSequence.