### PR TITLE
Maintain order of YamlSequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,15 +63,13 @@ YamlMapping yaml = Yaml.createYamlMappingBuilder()
 ```yaml
 architect: amihaiemil
 developers: 
-  - SherifWally
   - amihaiemil
   - salikjan
+  - SherifWally
 devops: 
-  - 0pdd
   - rultor
+  - 0pdd
 ```
-
-Note that the elements of both mappings and sequences are sorted alphabetically, even though this is not explicitly required by the YAML specification.
 
 ## Reading:
 

--- a/src/main/java/com/amihaiemil/camel/ReadYamlSequence.java
+++ b/src/main/java/com/amihaiemil/camel/ReadYamlSequence.java
@@ -28,8 +28,7 @@ final class ReadYamlSequence extends AbstractYamlSequence {
     @Override
     public Collection<YamlNode> children() {
         final List<YamlNode> kids = new LinkedList<>();
-        final AbstractYamlLines ordered = new OrderedYamlLines(this.lines);
-        for(final YamlLine line : ordered) {
+        for(final YamlLine line : this.lines) {
             if("-".equals(line.trimmed())) {
                 kids.add(this.lines.nested(line.number()).toYamlNode(line));
             } else {
@@ -49,7 +48,7 @@ final class ReadYamlSequence extends AbstractYamlSequence {
 
     @Override
     public String indent(final int indentation) {
-        return new OrderedYamlLines(this.lines).indent(indentation);
+        return this.lines.indent(indentation);
     }
 
     @Override

--- a/src/main/java/com/amihaiemil/camel/RtYamlLines.java
+++ b/src/main/java/com/amihaiemil/camel/RtYamlLines.java
@@ -87,21 +87,23 @@ final class RtYamlLines extends AbstractYamlLines {
     String indent(final int indentation) {
         final StringBuilder indented = new StringBuilder();
         final Iterator<YamlLine> linesIt = this.lines.iterator();
-        final YamlLine first = linesIt.next();
-        if (first.indentation() == indentation) {
-            indented.append(first.toString()).append("\n");
-            while (linesIt.hasNext()) {
-                indented.append(linesIt.next().toString()).append("\n");
-            }
-        } else {
-            final int offset = indentation - first.indentation();
-            for (final YamlLine line : this.lines) {
-                int correct = line.indentation() + offset;
-                while (correct > 0) {
-                    indented.append(" ");
-                    correct--;
+        if(linesIt.hasNext()) {
+            final YamlLine first = linesIt.next();
+            if (first.indentation() == indentation) {
+                indented.append(first.toString()).append("\n");
+                while (linesIt.hasNext()) {
+                    indented.append(linesIt.next().toString()).append("\n");
                 }
-                indented.append(line.trimmed()).append("\n");
+            } else {
+                final int offset = indentation - first.indentation();
+                for (final YamlLine line : this.lines) {
+                    int correct = line.indentation() + offset;
+                    while (correct > 0) {
+                        indented.append(" ");
+                        correct--;
+                    }
+                    indented.append(line.trimmed()).append("\n");
+                }
             }
         }
         return indented.toString();

--- a/src/main/java/com/amihaiemil/camel/RtYamlSequence.java
+++ b/src/main/java/com/amihaiemil/camel/RtYamlSequence.java
@@ -28,7 +28,6 @@
 package com.amihaiemil.camel;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -52,7 +51,6 @@ final class RtYamlSequence extends AbstractYamlSequence {
      */
     RtYamlSequence(final Collection<YamlNode> elements) {
         this.nodes.addAll(elements);
-        Collections.sort(this.nodes);
     }
 
     @Override

--- a/src/test/java/com/amihaiemil/camel/ReadYamlSequenceTest.java
+++ b/src/test/java/com/amihaiemil/camel/ReadYamlSequenceTest.java
@@ -61,7 +61,7 @@ public final class ReadYamlSequenceTest {
         final YamlSequence sequence = new ReadYamlSequence(
             new RtYamlLines(lines)
         );
-        final YamlMapping alfa = sequence.yamlMapping(1);
+        final YamlMapping alfa = sequence.yamlMapping(2);
         MatcherAssert.assertThat(alfa, Matchers.notNullValue());
         MatcherAssert.assertThat(alfa, Matchers.instanceOf(YamlMapping.class));
         MatcherAssert.assertThat(
@@ -85,7 +85,7 @@ public final class ReadYamlSequenceTest {
         final YamlSequence sequence = new ReadYamlSequence(
             new RtYamlLines(lines)
         );
-        final YamlSequence devops = sequence.yamlSequence(2);
+        final YamlSequence devops = sequence.yamlSequence(0);
         MatcherAssert.assertThat(devops, Matchers.notNullValue());
         MatcherAssert.assertThat(
             devops, Matchers.instanceOf(YamlSequence.class)
@@ -106,8 +106,8 @@ public final class ReadYamlSequenceTest {
         final YamlSequence devops = new ReadYamlSequence(
             new RtYamlLines(lines)
         );
-        MatcherAssert.assertThat(devops.string(0), Matchers.equalTo("0pdd"));
-        MatcherAssert.assertThat(devops.string(1), Matchers.equalTo("rultor"));
+        MatcherAssert.assertThat(devops.string(0), Matchers.equalTo("rultor"));
+        MatcherAssert.assertThat(devops.string(1), Matchers.equalTo("0pdd"));
     }
     
     /**

--- a/src/test/java/com/amihaiemil/camel/RtYamlInputTest.java
+++ b/src/test/java/com/amihaiemil/camel/RtYamlInputTest.java
@@ -29,8 +29,8 @@ public final class RtYamlInputTest {
             .add("developers",
                 Yaml.createYamlSequenceBuilder()
                     .add("rultor")
-                    .add("sherif")
                     .add("salikjan")
+                    .add("sherif")
                     .build()
             ).build();
         YamlMapping read = new RtYamlInput(
@@ -62,7 +62,6 @@ public final class RtYamlInputTest {
             read.yamlSequence("developers").string(2),
             Matchers.equalTo(expected.yamlSequence("developers").string(2))
         );
-        System.out.println(read);
         MatcherAssert.assertThat(
             read, Matchers.equalTo(expected)
         );

--- a/src/test/java/com/amihaiemil/camel/RtYamlMappingTest.java
+++ b/src/test/java/com/amihaiemil/camel/RtYamlMappingTest.java
@@ -254,8 +254,8 @@ public final class RtYamlMappingTest {
             .add("developers",
                 Yaml.createYamlSequenceBuilder()
                     .add("rultor")
-                    .add("sherif")
                     .add("salikjan")
+                    .add("sherif")
                     .build()
             ).build();
         String expected = this.readTestResource("simpleMapping.yml");
@@ -271,8 +271,8 @@ public final class RtYamlMappingTest {
         YamlMapping yaml = Yaml.createYamlMappingBuilder()
             .add(
                 Yaml.createYamlSequenceBuilder()
-                    .add("Detroit Tigers")
                     .add("Chicago cubs")
+                    .add("Detroit Tigers")
                     .build(),
                 Yaml.createYamlSequenceBuilder()
                     .add("2001-07-23")
@@ -280,8 +280,8 @@ public final class RtYamlMappingTest {
             )
             .add(
                 Yaml.createYamlSequenceBuilder()
-                    .add("New York Yankees")
                     .add("Atlanta Braves")
+                    .add("New York Yankees")
                     .build(),
                 Yaml.createYamlSequenceBuilder()
                     .add("2001-07-02")

--- a/src/test/java/com/amihaiemil/camel/RtYamlSequenceTest.java
+++ b/src/test/java/com/amihaiemil/camel/RtYamlSequenceTest.java
@@ -69,10 +69,10 @@ public final class RtYamlSequenceTest {
     }
     
     /**
-     * A Sequence is ordered.
+     * A Sequence maintains its order of reading.
      */
     @Test
-    public void sequenceIsOrdered() {
+    public void sequenceKeepsOrder() {
         List<YamlNode> nodes = new LinkedList<>();
         Scalar first = new Scalar("test");
         Scalar sec = new Scalar("mihai");
@@ -85,16 +85,16 @@ public final class RtYamlSequenceTest {
         RtYamlSequence seq = new RtYamlSequence(nodes);
         Iterator<YamlNode> ordered = seq.children().iterator();
         MatcherAssert.assertThat(
-            (Scalar) ordered.next(), Matchers.equalTo(fourth)
-        );
-        MatcherAssert.assertThat(
-            (Scalar) ordered.next(), Matchers.equalTo(third)
+            (Scalar) ordered.next(), Matchers.equalTo(first)
         );
         MatcherAssert.assertThat(
             (Scalar) ordered.next(), Matchers.equalTo(sec)
         );
         MatcherAssert.assertThat(
-            (Scalar) ordered.next(), Matchers.equalTo(first)
+            (Scalar) ordered.next(), Matchers.equalTo(third)
+        );
+        MatcherAssert.assertThat(
+            (Scalar) ordered.next(), Matchers.equalTo(fourth)
         );
     }
     
@@ -109,7 +109,7 @@ public final class RtYamlSequenceTest {
         nodes.add(new Scalar("mihai"));
         YamlSequence seq = new RtYamlSequence(nodes);
         MatcherAssert.assertThat(
-            seq.string(1), Matchers.equalTo("mihai")
+            seq.string(1), Matchers.equalTo("amber")
         );
         MatcherAssert.assertThat(
             seq.yamlMapping(1), Matchers.nullValue()
@@ -127,10 +127,7 @@ public final class RtYamlSequenceTest {
         nodes.add(new Scalar("mihai"));
         YamlSequence seq = new RtYamlSequence(nodes);
         MatcherAssert.assertThat(
-            seq.yamlMapping(2), Matchers.notNullValue()
-        );
-        MatcherAssert.assertThat(
-            seq.yamlMapping(1), Matchers.nullValue()
+            seq.yamlMapping(1), Matchers.notNullValue()
         );
     }
 
@@ -221,9 +218,9 @@ public final class RtYamlSequenceTest {
     public void prettyPrintsSimpleYamlSequence() throws Exception {
         YamlSequence seq = Yaml.createYamlSequenceBuilder()
             .add("amihaiemil")
-            .add("sherif")
-            .add("salikjan")
             .add("rultor")
+            .add("salikjan")
+            .add("sherif")
             .build();
         String expected = this.readTestResource("simpleSequence.yml");
         MatcherAssert.assertThat(seq.toString(), Matchers.equalTo(expected));
@@ -247,14 +244,6 @@ public final class RtYamlSequenceTest {
     public void prettyPrintsComplexYamlSequence() throws Exception {
         YamlSequence seq = Yaml.createYamlSequenceBuilder()
             .add("amihaiemil")
-            .add(
-                Yaml
-                    .createYamlMappingBuilder()
-                    .add("rule1", "test")
-                    .add("rule2", "test2")
-                    .add("rule3", "test3")
-                    .build()
-            )
             .add("salikjan")
             .add(
                 Yaml.createYamlSequenceBuilder()
@@ -262,7 +251,13 @@ public final class RtYamlSequenceTest {
                     .add("element2")
                     .add("element3")
                     .build()
-            )
+            ).add(
+                Yaml.createYamlMappingBuilder()
+                    .add("rule1", "test")
+                    .add("rule2", "test2")
+                    .add("rule3", "test3")
+                    .build()
+                )
             .build();
         String expected = this.readTestResource("complexSequence.yml");
         MatcherAssert.assertThat(seq.toString(), Matchers.equalTo(expected));

--- a/src/test/java/com/amihaiemil/camel/YamlCollectionDumpTest.java
+++ b/src/test/java/com/amihaiemil/camel/YamlCollectionDumpTest.java
@@ -58,9 +58,8 @@ public final class YamlCollectionDumpTest {
         
         YamlSequence yaml = new YamlCollectionDump(collection).represent();
         MatcherAssert.assertThat(yaml.children().size(), Matchers.equalTo(2));
-        MatcherAssert.assertThat(yaml.string(0), Matchers.equalTo("objectA"));
-        
-        YamlMapping yamlMapping = yaml.yamlMapping(1);
+
+        YamlMapping yamlMapping = yaml.yamlMapping(0);
         MatcherAssert.assertThat(
             yamlMapping.string("firstName"),
             Matchers.equalTo("John")
@@ -77,5 +76,6 @@ public final class YamlCollectionDumpTest {
             yamlMapping.string("gpa"),
             Matchers.equalTo("4.0")
         );
+        MatcherAssert.assertThat(yaml.string(1), Matchers.equalTo("objectA"));
     }
 }


### PR DESCRIPTION
Fixes #129 

YamlSequence now maintains the order of reading or building.